### PR TITLE
Check env var value in loader

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 SHOW_ITEM_SKU="true"
+SHOW_ITEM_PAGE="false"

--- a/app/context/FeatureFlagContext.tsx
+++ b/app/context/FeatureFlagContext.tsx
@@ -2,6 +2,7 @@ import { ReactNode, createContext, useContext } from 'react'
 
 type FeatureFlagContextType = {
     showItemSku: boolean
+    showItemPage: boolean
 }
 
 export const FeatureFlagContext = createContext<

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,7 +1,8 @@
 type FeatureFlagValues = 'true' | 'false'
 
-declare namespace NodeJS { 
+declare namespace NodeJS {
     export interface ProcessEnv {
-        SHOW_ITEM_SKU: FeatureFlagValues;
+        SHOW_ITEM_SKU: FeatureFlagValues
+        SHOW_ITEM_PAGE: FeatureFlagValues
     }
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -24,12 +24,13 @@ export const links: LinksFunction = () => [
 
 export const loader = () => {
     const showItemSku = process.env.SHOW_ITEM_SKU === 'true'
+    const showItemPage = process.env.SHOW_ITEM_PAGE === 'true'
 
-    return { showItemSku }
+    return { showItemSku, showItemPage }
 }
 
 export default function App() {
-    const { showItemSku } = useLoaderData<typeof loader>()
+    const { showItemSku, showItemPage } = useLoaderData<typeof loader>()
 
     return (
         <html lang="en">
@@ -43,7 +44,7 @@ export default function App() {
                 <Links />
             </head>
             <body>
-                <FeatureFlagProvider value={{ showItemSku }}>
+                <FeatureFlagProvider value={{ showItemSku, showItemPage }}>
                     <Outlet />
                 </FeatureFlagProvider>
                 <ScrollRestoration />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,18 +1,18 @@
-import { useLoaderData } from '@remix-run/react'
+import { Link, useLoaderData } from '@remix-run/react'
 import { InventoryItem } from '~/components/InventoryItem'
+import { useFeatureFlagContext } from '~/context/FeatureFlagContext'
 import { inventoryList } from '~/data/inventory'
 
 export const loader = () => {
     // in lieu of a fetching from an external source...
     const inventoryItems = inventoryList
 
-    const showItemSku = process.env.SHOW_ITEM_SKU
-
-    return { inventoryItems, showItemSku }
+    return { inventoryItems }
 }
 
 export const InventoryPage = () => {
-    const { inventoryItems, showItemSku } = useLoaderData<typeof loader>()
+    const { inventoryItems } = useLoaderData<typeof loader>()
+    const { showItemPage } = useFeatureFlagContext()
 
     return (
         <div className="relative flex min-h-screen flex-col items-center bg-slate-100">
@@ -20,9 +20,16 @@ export const InventoryPage = () => {
                 <h1 className="my-8 text-3xl">Inventory</h1>
             </div>
             <div className="flex flex-col items-center gap-2 py-8">
-                {inventoryItems.map((item) => (
-                    <InventoryItem key={item.id} item={item} />
-                ))}
+                {inventoryItems.map((item) => {
+                    if (showItemPage) {
+                        return (
+                            <Link to={`/inventory/${item.id}`} key={item.id}>
+                                <InventoryItem key={item.id} item={item} />
+                            </Link>
+                        )
+                    }
+                    return <InventoryItem key={item.id} item={item} />
+                })}
             </div>
         </div>
     )

--- a/app/routes/inventory.$id.tsx
+++ b/app/routes/inventory.$id.tsx
@@ -11,9 +11,15 @@ export const loader = ({ params }: LoaderFunctionArgs) => {
 
     invariant(inventoryItem, 'Inventory item not found')
 
-    const showItemSku = process.env.SHOW_ITEM_SKU
+    const showItemPage = process.env.SHOW_ITEM_PAGE
 
-    return { inventoryItem, showItemSku }
+    if (!showItemPage) {
+        throw new Response(null, {
+            status: 404,
+            statusText: 'Not Found',
+        })
+    }
+    return { inventoryItem }
 }
 
 const InventoryItemPage = () => {

--- a/app/routes/inventory.$id.tsx
+++ b/app/routes/inventory.$id.tsx
@@ -13,7 +13,7 @@ export const loader = ({ params }: LoaderFunctionArgs) => {
 
     const showItemPage = process.env.SHOW_ITEM_PAGE
 
-    if (!showItemPage) {
+    if (showItemPage === 'false') {
         throw new Response(null, {
             status: 404,
             statusText: 'Not Found',


### PR DESCRIPTION
- Add SHOW_ITEM_PAGE to the .env file and type information to the global.d.ts file.
- Check the environment variable value in the serialized item page loader. Throw a 404 if the value is false.
- Add `SHOW_ITEM_PAGE` to the feature flag context. Use this context value to either render a link, or render the regular inventory card.
- Fixed a small bug in checking the value of the env var in the inventory/$id loader.